### PR TITLE
Change to using npm to publish the package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,32 +1,21 @@
-name: Publish NPM Package
-
+name: Publish Package to npmjs
 on:
   release:
     types: [published]
-
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-
+      id-token: write
+    environment: production
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          registry-url: 'https://npm.pkg.github.com/'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build package
-        run: npm run build
-
-      - name: Publish to GitHub Packages Registry
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - name: Publish the package
+        run: npm publish --provenance --access public

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-@runtimed/anaconda:registry=https://npm.pkg.github.com/
-always-auth=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Version 0.1.0 (Initial commit)
+
+- Sets up the repository with typescript
+- Implements the BackendExtension with ApiKey support

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# anaconda_extension
+# @runtimed/anaconda
 
-Anaconda-specific integrations for Runt
+This extension provides the Anaconda-specific customizations to the Runt Web.
+It is utilized on https://app.runt.run and integrates the api key API (with more integrations to come)
+
+# Development
+
+This is a simple typescript repository. You just `npm install` to set up dependencies. When you're ready to make a commit, run `npm run build` and `npm run format` to ensure the types pass & format the files respectively. If you forget, the CI will check it for you
+
+# Publishing
+
+1. Create a new branch
+1. Update the [CHANGELOG.md](./CHANGELOG.md)
+1. Change the version in package.json
+1. run `npm install` to update the package-lock.json file
+1. Commit, and create a PR
+1. Merge the PR into main
+1. Create a new release. Copy over the contents from the [CHANGELOG](./CHANGELOG.md)
+1. The [publish](./.github/workflows/publish.yml) action will automatically push the release to npm

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "dist",
     "README.md"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write .",


### PR DESCRIPTION
Using github's registry is more trouble than its worth right now. Switch to npm, and we can change our mind later if need be